### PR TITLE
Optimize the initializer

### DIFF
--- a/2017/src/simpleknot/simpleknot.go
+++ b/2017/src/simpleknot/simpleknot.go
@@ -85,14 +85,9 @@ func initialize() []byte {
 }
 
 func New(input []byte) *Hash {
-	appended := input
-	for i := 0; i < len(hashSufix); i++ {
-		appended = append(appended, hashSufix[i])
-	}
-
 	return &Hash{
 		data:          initialize(),
 		rawInput:      input,
-		appendedInput: appended,
+		appendedInput: append(input,hashSuffix...),
 	}
 }


### PR DESCRIPTION
Don't need to iterate individually over `hashSuffix` since append will take it.